### PR TITLE
Persist spell descriptions in save files to eliminate redundant API fetches

### DIFF
--- a/src/features/FileManager.js
+++ b/src/features/FileManager.js
@@ -28,8 +28,9 @@ export class FileManager {
    *
    * @param {AppState} appState - Application state
    */
-  constructor(appState) {
+  constructor(appState, apiClient) {
     this.appState = appState;
+    this.apiClient = apiClient;
   }
 
   /**
@@ -56,7 +57,8 @@ export class FileManager {
           homeY: spell.homeY,
           whitelist: [...spell.whitelist],
           token: spell.token,
-          highlight: spell.highlight
+          highlight: spell.highlight,
+          cachedDescription: this.apiClient?.cache[spell.name] || null
         });
       }
     }
@@ -119,6 +121,15 @@ export class FileManager {
 
     if (!usedSpells || !Array.isArray(usedSpells)) {
       throw new Error('Invalid save file format: spells array not found');
+    }
+
+    // Restore API cache from saved descriptions
+    if (this.apiClient) {
+      for (const savedSpell of usedSpells) {
+        if (savedSpell.cachedDescription && !this.apiClient.cache[savedSpell.name]) {
+          this.apiClient.cache[savedSpell.name] = savedSpell.cachedDescription;
+        }
+      }
     }
 
     // Reset all spells first

--- a/src/main.js
+++ b/src/main.js
@@ -63,7 +63,7 @@ function initializeApp() {
   const spellFilter = new SpellFilter(appState);
   const spellSlotManager = new SpellSlotManager(appState);
   const tooltipManager = new TooltipManager(appState, apiClient);
-  const fileManager = new FileManager(appState);
+  const fileManager = new FileManager(appState, apiClient);
 
   // Initialize spell filter with all spells
   spellFilter.initializeAllSpells(initialSpells);


### PR DESCRIPTION
## Summary

Spell descriptions fetched from external APIs were only cached in memory, meaning every new browser session required re-fetching all descriptions by hovering each spell again. This change embeds the cached descriptions into the JSON save file and restores them into the API cache on load, so tooltips are instant from the first hover after loading a saved arrangement.

## Key Changes

- `FileManager` now accepts `apiClient` as a second constructor argument
- Each spell node in the saved JSON includes a `cachedDescription` field (the full API response object, or `null` if not yet fetched for that session)
- On load, any non-null `cachedDescription` values are written back into `apiClient.cache` before the spell arrangement is restored

## Implementation Details

- `src/main.js`: passes the existing `apiClient` instance to `FileManager` at construction time
- `src/features/FileManager.js`:
  - Constructor stores `this.apiClient`
  - `saveArrangement()`: adds `cachedDescription: this.apiClient?.cache[spell.name] || null` to each serialized spell — optional chaining means this is safe even if `apiClient` is absent
  - `applyLoadedData()`: iterates `usedSpells` before the reset loop and populates `apiClient.cache` for any spell that has a saved description, skipping entries already in cache to avoid overwriting fresher data

## Breaking Changes

None. Old save files without `cachedDescription` fields load correctly — the field is simply absent and the cache is not pre-populated (identical to current behaviour).
